### PR TITLE
feat: Clickable web uri in footnote

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -8,3 +8,8 @@ Neos:
     fusion:
       autoInclude:
         Psmb.Footnote: true
+
+Psmb:
+  Footnote:
+    autoLinking: false
+    nl2br: false

--- a/README.md
+++ b/README.md
@@ -36,3 +36,13 @@ prototype(Neos.Neos:PrimaryContent) {
   border-bottom: orange solid 1px;
 }
 ```
+
+6. Optionnally it is possible to disable the detection of web uri in order to not make them clickable. And disabling line break substition too.
+
+
+```
+Psmb:
+  Footnote:
+    autoLinking: true
+    nl2br: true
+```

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -11,7 +11,7 @@ prototype(Psmb.Footnote:FootnoteProcessor) < prototype(Neos.Fusion:Array) {
         value = ${value}
         @process.parse = Psmb.Footnote:PregReplaceCallback {
             @if.notInBackend = ${!documentNode.context.inBackend}
-            pattern = ${'/<span data-footnote="(.*?)">(.*?)<\/span>/'}
+            pattern = ${'/<span data-footnote="([^"]+)">([^<]+)<\/span>/'}
             subject = ${value}
             replacementRenderer = ${matches[2] + '<sup class="footnote" id="footnoteSource_' + iterator.cycle + '"><a href="#footnote_' + iterator.cycle + '">' + iterator.cycle + '</a></sup>'}
         }
@@ -20,10 +20,49 @@ prototype(Psmb.Footnote:FootnoteProcessor) < prototype(Neos.Fusion:Array) {
         @if.live = ${node.context.workspaceName == 'live'}
         @process.wrap = ${value && '<ul class="footnoteList">' + value + '</ul>'}
         collection = Psmb.Footnote:PregMatchAll {
-            pattern = ${'/<span data-footnote="(.*?)">(.*?)<\/span>/'}
+            pattern = ${'/<span data-footnote="([^"]+)">([^<]+)<\/span>/'}
             subject = ${value}
         }
         itemName = 'item'
-        itemRenderer = ${'<li class="footnoteList-item" id="footnote_' + iterator.cycle + '"><a href="#footnoteSource_' + iterator.cycle + '"><sup>' + iterator.cycle + '</sup></a> ' + item[1] + '</li>'}
+        itemRenderer = Psmb.Footnote:FootnoteProcessor.ItemRenderer
     }
+}
+
+prototype(Psmb.Footnote:FootnoteProcessor.ItemRenderer) < prototype(Neos.Fusion:Case) {
+    autoLinking {
+        condition = ${Configuration.setting('Psmb.Footnote.autoLinking') == true}
+        renderer = Psmb.Footnote:FootnoteProcessor.LinkRenderer
+    }
+    default {
+        condition = ${true}
+        renderer = Psmb.Footnote:FootnoteProcessor.ListItemRenderer
+    }
+}
+
+# Detect URI to make it clickable
+prototype(Psmb.Footnote:FootnoteProcessor.LinkRenderer) < prototype(Neos.Fusion:Value) {
+    element = ${item[1]}
+    element.@process {
+        linkUrl = Psmb.Footnote:PregReplaceCallback {
+            pattern = ${'#(https?:\/\/[^\s]+)#'}
+            subject = ${value}
+            replacementRenderer = ${'<a href="' + matches[1] + '">' + matches[1] + '</a>'}
+        }
+        lineBreak = ${Configuration.setting('Psmb.Footnote.nl2br') == true ? String.nl2br(value) : value}
+    }
+    @context.element = ${this.element}
+    value = Psmb.Footnote:FootnoteProcessor.ListItemRenderer
+}
+
+prototype(Psmb.Footnote:FootnoteProcessor.ListItemRenderer) < prototype(Neos.Fusion:Component) {
+    element = ${String.isBlank(element) == false ? element : item[1]}
+    id = ${'footnote_' + iterator.cycle}
+    anchor = ${'#footnoteSource_' + iterator.cycle}
+    index = ${iterator.cycle}
+
+    renderer = afx`
+        <li class="footnoteList-item" id={props.id}>
+            <a href={props.anchor}><sup>{props.index}</sup></a>{props.element}
+        </li>
+        `
 }


### PR DESCRIPTION
Detects web uri in order to make them clickable.
Allows to gather footnotes with multiline if there are any.
Options are by default disable in Settings